### PR TITLE
New Operation Example

### DIFF
--- a/libraries/chain/db_init.cpp
+++ b/libraries/chain/db_init.cpp
@@ -147,6 +147,7 @@ void database::initialize_evaluators()
    register_evaluator<asset_global_settle_evaluator>();
    register_evaluator<assert_evaluator>();
    register_evaluator<limit_order_create_evaluator>();
+   register_evaluator<limit_order_update_evaluator>();
    register_evaluator<limit_order_cancel_evaluator>();
    register_evaluator<call_order_update_evaluator>();
    register_evaluator<bid_collateral_evaluator>();

--- a/libraries/chain/db_notify.cpp
+++ b/libraries/chain/db_notify.cpp
@@ -43,6 +43,10 @@ struct get_impacted_account_visitor
    {
       _impacted.insert( op.fee_payer() ); // seller
    }
+   void operator()(const limit_order_update_operation& op)
+   {
+      _impacted.insert(op.fee_payer()); // seller
+   }
    void operator()( const limit_order_cancel_operation& op )
    {
       _impacted.insert( op.fee_payer() ); // fee_paying_account

--- a/libraries/chain/hardfork.d/CORE_1604.hf
+++ b/libraries/chain/hardfork.d/CORE_1604.hf
@@ -1,0 +1,4 @@
+// bitshares-core issue #1604 Operation to modify existing limit order
+#ifndef HARDFORK_CORE_1604_TIME
+#define HARDFORK_CORE_1604_TIME (fc::time_point_sec(1893456000)) // Jan 1 00:00:00 2030 (Not yet scheduled)
+#endif

--- a/libraries/chain/include/graphene/chain/market_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/market_evaluator.hpp
@@ -63,7 +63,7 @@ namespace graphene { namespace chain {
          const asset_object*                 _receive_asset = nullptr;
    };
 
-   class limit_order_update_evaluator : public evaluator<limit_order_update_operation>
+   class limit_order_update_evaluator : public evaluator<limit_order_update_evaluator>
    {
    public:
        using operation_type = limit_order_update_operation;

--- a/libraries/chain/include/graphene/chain/market_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/market_evaluator.hpp
@@ -63,6 +63,17 @@ namespace graphene { namespace chain {
          const asset_object*                 _receive_asset = nullptr;
    };
 
+   class limit_order_update_evaluator : public evaluator<limit_order_update_operation>
+   {
+   public:
+       using operation_type = limit_order_update_operation;
+
+       void_result do_evaluate(const limit_order_update_operation& o);
+       void_result do_apply(const limit_order_update_operation& o);
+
+       const limit_order_object* _order = nullptr;
+   };
+
    class limit_order_cancel_evaluator : public evaluator<limit_order_cancel_evaluator>
    {
       public:
@@ -71,7 +82,7 @@ namespace graphene { namespace chain {
          void_result do_evaluate( const limit_order_cancel_operation& o );
          asset do_apply( const limit_order_cancel_operation& o );
 
-         const limit_order_object* _order;
+         const limit_order_object* _order = nullptr;
    };
 
    class call_order_update_evaluator : public evaluator<call_order_update_evaluator>

--- a/libraries/chain/include/graphene/chain/market_evaluator.hpp
+++ b/libraries/chain/include/graphene/chain/market_evaluator.hpp
@@ -72,6 +72,7 @@ namespace graphene { namespace chain {
        void_result do_apply(const limit_order_update_operation& o);
 
        const limit_order_object* _order = nullptr;
+       bool should_match_orders = false;
    };
 
    class limit_order_cancel_evaluator : public evaluator<limit_order_cancel_evaluator>

--- a/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/fee_schedule.hpp
@@ -140,6 +140,12 @@ namespace graphene { namespace chain {
       {
          return fee_helper<Operation>().get(parameters);
       }
+      template<typename Operation>
+      const bool exists()const
+      {
+         auto itr = parameters.find(typename Operation::fee_parameters_type());
+         return itr != parameters.end();
+      }
 
       /**
        *  @note must be sorted by fee_parameters.which() and have no duplicates

--- a/libraries/chain/include/graphene/chain/protocol/market.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/market.hpp
@@ -96,7 +96,7 @@ namespace graphene { namespace chain {
 
        extensions_type extensions;
 
-       account_id_type fee_payer() { return seller; }
+       account_id_type fee_payer() const { return seller; }
        void validate() const;
        share_type calculate_fee(const fee_parameters_type& k) const {
            return delta_amount_to_sell? k.amount_fee : k.price_fee;

--- a/libraries/chain/include/graphene/chain/protocol/market.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/market.hpp
@@ -73,6 +73,35 @@ namespace graphene { namespace chain {
       price           get_price()const { return amount_to_sell / min_to_receive; }
    };
 
+   /**
+    * @ingroup operations
+    * Used to update an existing limit order.
+    *
+    * Charges a higher fee if @ref delta_amount_to_sell is set, as this requires updating
+    * the account balance as well as the order object.
+    */
+   struct limit_order_update_operation : public base_operation
+   {
+       struct fee_parameters_type {
+           uint64_t price_fee = GRAPHENE_BLOCKCHAIN_PRECISION / 2;
+           uint64_t amount_fee = GRAPHENE_BLOCKCHAIN_PRECISION;
+       };
+
+       asset fee;
+       account_id_type seller;
+       limit_order_id_type order;
+       optional<price> new_price;
+       optional<asset> delta_amount_to_sell;
+       optional<time_point_sec> new_expiration;
+
+       extensions_type extensions;
+
+       account_id_type fee_payer() { return seller; }
+       void validate() const;
+       share_type calculate_fee(const fee_parameters_type& k) const {
+           return delta_amount_to_sell? k.amount_fee : k.price_fee;
+       }
+   };
 
    /**
     *  @ingroup operations
@@ -219,6 +248,7 @@ namespace graphene { namespace chain {
 } } // graphene::chain
 
 FC_REFLECT( graphene::chain::limit_order_create_operation::fee_parameters_type, (fee) )
+FC_REFLECT( graphene::chain::limit_order_update_operation::fee_parameters_type, (price_fee)(amount_fee) )
 FC_REFLECT( graphene::chain::limit_order_cancel_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::call_order_update_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::bid_collateral_operation::fee_parameters_type, (fee) )
@@ -230,6 +260,7 @@ FC_REFLECT( graphene::chain::call_order_update_operation::options_type, (target_
 FC_REFLECT_TYPENAME( graphene::chain::call_order_update_operation::extensions_type )
 
 FC_REFLECT( graphene::chain::limit_order_create_operation,(fee)(seller)(amount_to_sell)(min_to_receive)(expiration)(fill_or_kill)(extensions))
+FC_REFLECT( graphene::chain::limit_order_update_operation,(fee)(seller)(order)(new_price)(delta_amount_to_sell)(new_expiration)(extensions))
 FC_REFLECT( graphene::chain::limit_order_cancel_operation,(fee)(fee_paying_account)(order)(extensions) )
 FC_REFLECT( graphene::chain::call_order_update_operation, (fee)(funding_account)(delta_collateral)(delta_debt)(extensions) )
 FC_REFLECT( graphene::chain::fill_order_operation, (fee)(order_id)(account_id)(pays)(receives)(fill_price)(is_maker) )

--- a/libraries/chain/include/graphene/chain/protocol/market.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/market.hpp
@@ -76,15 +76,11 @@ namespace graphene { namespace chain {
    /**
     * @ingroup operations
     * Used to update an existing limit order.
-    *
-    * Charges a higher fee if @ref delta_amount_to_sell is set, as this requires updating
-    * the account balance as well as the order object.
     */
    struct limit_order_update_operation : public base_operation
    {
        struct fee_parameters_type {
-           uint64_t price_fee = GRAPHENE_BLOCKCHAIN_PRECISION / 2;
-           uint64_t amount_fee = GRAPHENE_BLOCKCHAIN_PRECISION;
+           uint64_t fee = GRAPHENE_BLOCKCHAIN_PRECISION / 2;
        };
 
        asset fee;
@@ -99,7 +95,7 @@ namespace graphene { namespace chain {
        account_id_type fee_payer() const { return seller; }
        void validate() const;
        share_type calculate_fee(const fee_parameters_type& k) const {
-           return delta_amount_to_sell? k.amount_fee : k.price_fee;
+           return k.fee;
        }
    };
 
@@ -248,7 +244,7 @@ namespace graphene { namespace chain {
 } } // graphene::chain
 
 FC_REFLECT( graphene::chain::limit_order_create_operation::fee_parameters_type, (fee) )
-FC_REFLECT( graphene::chain::limit_order_update_operation::fee_parameters_type, (price_fee)(amount_fee) )
+FC_REFLECT( graphene::chain::limit_order_update_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::limit_order_cancel_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::call_order_update_operation::fee_parameters_type, (fee) )
 FC_REFLECT( graphene::chain::bid_collateral_operation::fee_parameters_type, (fee) )

--- a/libraries/chain/include/graphene/chain/protocol/operations.hpp
+++ b/libraries/chain/include/graphene/chain/protocol/operations.hpp
@@ -95,7 +95,8 @@ namespace graphene { namespace chain {
             bid_collateral_operation,
             execute_bid_operation,          // VIRTUAL
             asset_claim_pool_operation,
-            asset_update_issuer_operation
+            asset_update_issuer_operation,
+            limit_order_update_operation
          > operation;
 
    /// @} // operations group

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -175,8 +175,8 @@ void_result limit_order_update_evaluator::do_evaluate(const limit_order_update_o
 
    // Check expiration is in the future
    if (o.new_expiration)
-      FC_ASSERT(*o.new_expiration >= d.head_block_time(),
-                "Cannot update limit order with past expiration");
+      FC_ASSERT(*o.new_expiration > _order->expiration,
+                "Cannot update limit order to expire sooner; new expiration must be later than old one.");
 
    return {};
 } FC_CAPTURE_AND_RETHROW((o)) }

--- a/libraries/chain/market_evaluator.cpp
+++ b/libraries/chain/market_evaluator.cpp
@@ -127,6 +127,7 @@ object_id_type limit_order_create_evaluator::do_apply(const limit_order_create_o
 void_result limit_order_update_evaluator::do_evaluate(const limit_order_update_operation& o)
 { try {
    const database& d = db();
+   FC_ASSERT(d.head_block_time() > HARDFORK_CORE_1604_TIME, "Operation has not activated yet");
    _order = &o.order(d);
 
    // Check this is my order

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -96,6 +96,11 @@ struct proposal_operation_hardfork_visitor
          FC_ASSERT(!"Virtual operation");
       }
    }
+   void operator()(const graphene::chain::committee_member_update_global_parameters_operation &op) const {
+       if (block_time < HARDFORK_CORE_1604_TIME)
+           FC_ASSERT(!op.new_parameters.current_fees->exists<graphene::chain::limit_order_update_operation>(),
+                     "Cannot set fees for limit_order_update_operation before its hardfork time");
+   }
    // loop and self visit in proposals
    void operator()(const graphene::chain::proposal_create_operation &v) const {
       for (const op_wrapper &op : v.proposed_ops)

--- a/libraries/chain/proposal_evaluator.cpp
+++ b/libraries/chain/proposal_evaluator.cpp
@@ -42,6 +42,10 @@ struct proposal_operation_hardfork_visitor
    void operator()(const T &v) const {}
 
    // TODO review and cleanup code below after hard fork
+   // hf_1604
+   void operator()(const graphene::chain::limit_order_update_operation &) const {
+      FC_ASSERT(block_time > HARDFORK_CORE_1604_TIME, "Operation is not enabled yet");
+   }
    // hf_834
    void operator()(const graphene::chain::call_order_update_operation &v) const {
       if (next_maintenance_time <= HARDFORK_CORE_834_TIME) {

--- a/libraries/chain/protocol/market.cpp
+++ b/libraries/chain/protocol/market.cpp
@@ -65,6 +65,4 @@ void bid_collateral_operation::validate()const
    FC_ASSERT( debt_covered.amount == 0 || (debt_covered.amount > 0 && additional_collateral.amount > 0) );
 } FC_CAPTURE_AND_RETHROW((*this)) }
 
-}
-
-} // graphene::chain
+} } // graphene::chain

--- a/libraries/chain/protocol/market.cpp
+++ b/libraries/chain/protocol/market.cpp
@@ -34,15 +34,15 @@ void limit_order_create_operation::validate()const
 }
 
 void limit_order_update_operation::validate() const
-{
+{ try {
    FC_ASSERT(fee.amount >= 0, "Fee must not be negative");
    FC_ASSERT(new_price || delta_amount_to_sell || new_expiration,
-              "Cannot update limit order if nothing is specified to update");
+             "Cannot update limit order if nothing is specified to update");
    if (new_price)
-       new_price->validate();
+      new_price->validate();
    if (delta_amount_to_sell)
-       FC_ASSERT(delta_amount_to_sell->amount != 0, "Cannot change limit order amount by zero");
-}
+      FC_ASSERT(delta_amount_to_sell->amount != 0, "Cannot change limit order amount by zero");
+} FC_CAPTURE_AND_RETHROW((*this)) }
 
 void limit_order_cancel_operation::validate()const
 {

--- a/libraries/chain/protocol/market.cpp
+++ b/libraries/chain/protocol/market.cpp
@@ -33,6 +33,17 @@ void limit_order_create_operation::validate()const
    FC_ASSERT( min_to_receive.amount > 0 );
 }
 
+void limit_order_update_operation::validate() const
+{
+   FC_ASSERT(fee.amount >= 0, "Fee must not be negative");
+   FC_ASSERT(new_price || delta_amount_to_sell || new_expiration,
+              "Cannot update limit order if nothing is specified to update");
+   if (new_price)
+       new_price->validate();
+   if (delta_amount_to_sell)
+       FC_ASSERT(delta_amount_to_sell->amount != 0, "Cannot change limit order amount by zero");
+}
+
 void limit_order_cancel_operation::validate()const
 {
    FC_ASSERT( fee.amount >= 0 );
@@ -54,4 +65,6 @@ void bid_collateral_operation::validate()const
    FC_ASSERT( debt_covered.amount == 0 || (debt_covered.amount > 0 && additional_collateral.amount > 0) );
 } FC_CAPTURE_AND_RETHROW((*this)) }
 
-} } // graphene::chain
+}
+
+} // graphene::chain

--- a/tests/common/database_fixture.hpp
+++ b/tests/common/database_fixture.hpp
@@ -331,6 +331,14 @@ struct database_fixture {
    const limit_order_object* create_sell_order( const account_object& user, const asset& amount, const asset& recv,
                                                 const time_point_sec order_expiration = time_point_sec::maximum(),
                                                 const price& fee_core_exchange_rate = price::unit_price() );
+   void update_limit_order(const limit_order_object& order,
+                           fc::optional<price> new_price = {},
+                           fc::optional<asset> delta_amount = {},
+                           fc::optional<time_point_sec> new_expiration = {});
+   void update_limit_order(limit_order_id_type order_id,
+                           fc::optional<price> new_price = {},
+                           fc::optional<asset> delta_amount = {},
+                           fc::optional<time_point_sec> new_expiration = {});
    asset cancel_limit_order( const limit_order_object& order );
    void transfer( account_id_type from, account_id_type to, const asset& amount, const asset& fee = asset() );
    void transfer( const account_object& from, const account_object& to, const asset& amount, const asset& fee = asset() );

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -80,6 +80,98 @@ BOOST_AUTO_TEST_CASE( feed_limit_logic_test )
    }
 }
 
+BOOST_AUTO_TEST_CASE(limit_order_update_test)
+{
+   try {
+      ACTORS((nathan));
+      const auto& bitusd = create_bitasset("USDBIT", nathan.id);
+      const auto& munee = create_user_issued_asset("MUNEE");
+      const auto& core   = asset_id_type()(db);
+
+      update_feed_producers(bitusd, {nathan_id});
+      price_feed current_feed;
+      current_feed.settlement_price = bitusd.amount(200) / core.amount(100);
+      current_feed.maintenance_collateral_ratio = 1750;
+      publish_feed(bitusd, nathan, current_feed);
+
+      transfer(committee_account, nathan_id, asset(1500));
+      issue_uia(nathan, munee.amount(100));
+      borrow(nathan_id, bitusd.amount(100), asset(500));
+
+      auto expiration = db.head_block_time() + 1000;
+      auto sell_price = price(asset(500), bitusd.amount(1000));
+      limit_order_id_type order_id = create_sell_order(nathan, asset(500), bitusd.amount(1000), expiration)->id;
+      BOOST_REQUIRE_EQUAL(order_id(db).for_sale.value, 500);
+      BOOST_REQUIRE_EQUAL(fc::json::to_string(order_id(db).sell_price), fc::json::to_string(sell_price));
+      BOOST_REQUIRE_EQUAL(order_id(db).expiration.sec_since_epoch(), expiration.sec_since_epoch());
+
+      // Cannot update order without changing anything
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id), fc::assert_exception);
+      // Cannot update order to use inverted price assets
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(bitusd.amount(2), asset(1))), fc::assert_exception);
+      // Cannot update order to use different assets
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(bitusd.amount(2), munee.amount(1))), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(munee.amount(2), bitusd.amount(1))), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(asset(2), munee.amount(1))), fc::assert_exception);
+      // Cannot update order to expire in the past
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, {}, db.head_block_time() - 10), fc::assert_exception);
+      // Cannot update order to add more funds than seller has
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, asset(501)), fc::assert_exception);
+      // Cannot update order to remove more funds than order has
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, asset(-501)), fc::assert_exception);
+      // Cannot update order to remove all funds in order
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, asset(-500)), fc::assert_exception);
+      // Cannot update order to add or remove different kind of funds
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, bitusd.amount(50)), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, bitusd.amount(-50)), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, munee.amount(50)), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, munee.amount(-50)), fc::assert_exception);
+
+      // Try changing price
+      sell_price.base = asset(501);
+      update_limit_order(order_id, sell_price);
+      BOOST_REQUIRE_EQUAL(fc::json::to_string(order_id(db).sell_price), fc::json::to_string(sell_price));
+      sell_price.base = asset(500);
+      sell_price.quote = bitusd.amount(999);
+      update_limit_order(order_id, sell_price);
+      BOOST_REQUIRE_EQUAL(fc::json::to_string(order_id(db).sell_price), fc::json::to_string(sell_price));
+      sell_price.quote = bitusd.amount(1000);
+      update_limit_order(order_id, sell_price);
+      BOOST_REQUIRE_EQUAL(fc::json::to_string(order_id(db).sell_price), fc::json::to_string(sell_price));
+
+      // Try changing expiration
+      expiration += 50;
+      update_limit_order(order_id, {}, {}, expiration);
+      BOOST_REQUIRE_EQUAL(order_id(db).expiration.sec_since_epoch(), expiration.sec_since_epoch());
+      expiration -= 100;
+      update_limit_order(order_id, {}, {}, expiration);
+      BOOST_REQUIRE_EQUAL(order_id(db).expiration.sec_since_epoch(), expiration.sec_since_epoch());
+
+      // Try adding funds
+      update_limit_order(order_id, {}, asset(50));
+      BOOST_REQUIRE_EQUAL(order_id(db).amount_for_sale().amount.value, 550);
+      BOOST_REQUIRE_EQUAL(db.get_balance(nathan_id, core.get_id()).amount.value, 450);
+
+      // Try removing funds
+      update_limit_order(order_id, {}, asset(-100));
+      BOOST_REQUIRE_EQUAL(order_id(db).amount_for_sale().amount.value, 450);
+      BOOST_REQUIRE_EQUAL(db.get_balance(nathan_id, core.get_id()).amount.value, 550);
+
+      // Try changing everything at once
+      expiration += 50;
+      sell_price.base = asset(499);
+      sell_price.quote = bitusd.amount(1001);
+      update_limit_order(order_id, sell_price, 50, expiration);
+      BOOST_REQUIRE_EQUAL(fc::json::to_string(order_id(db).sell_price), fc::json::to_string(sell_price));
+      BOOST_REQUIRE_EQUAL(order_id(db).expiration.sec_since_epoch(), expiration.sec_since_epoch());
+      BOOST_REQUIRE_EQUAL(order_id(db).amount_for_sale().amount.value, 500);
+      BOOST_REQUIRE_EQUAL(db.get_balance(nathan_id, core.get_id()).amount.value, 500);
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_CASE( call_order_update_test )
 {
    try {

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -172,6 +172,27 @@ BOOST_AUTO_TEST_CASE(limit_order_update_test)
    }
 }
 
+BOOST_AUTO_TEST_CASE(limit_order_update_dust_test)
+{
+   try {
+      ACTORS((nathan));
+      const auto& munee = create_user_issued_asset("MUNEE");
+
+      transfer(committee_account, nathan_id, asset(10000));
+      issue_uia(nathan, munee.amount(1000));
+
+      auto expiration = db.head_block_time() + 1000;
+      limit_order_id_type order_id = create_sell_order(nathan, asset(1000), munee.amount(100), expiration)->id;
+
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, asset(-995)), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(asset(1000000), munee.amount(100))), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(asset(2000), munee.amount(100)), asset(-985)), fc::assert_exception);
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_CASE(limit_order_update_match_test)
 {
    try {

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -172,6 +172,50 @@ BOOST_AUTO_TEST_CASE(limit_order_update_test)
    }
 }
 
+BOOST_AUTO_TEST_CASE(limit_order_update_match_test)
+{
+   try {
+      ACTORS((nathan));
+      const auto& munee = create_user_issued_asset("MUNEE");
+
+      transfer(committee_account, nathan_id, asset(10000));
+      issue_uia(nathan, munee.amount(1000));
+
+      auto expiration = db.head_block_time() + 1000;
+      limit_order_id_type order_id_1 = create_sell_order(nathan, asset(999), munee.amount(100), expiration)->id;
+      limit_order_id_type order_id_2 = create_sell_order(nathan, munee.amount(100), asset(1001), expiration)->id;
+
+      update_limit_order(order_id_1, price(asset(1001), munee.amount(100)), asset(1));
+      BOOST_REQUIRE_EQUAL(db.find(order_id_1), nullptr);
+      BOOST_REQUIRE_EQUAL(db.find(order_id_2)->amount_for_sale().amount.value, 1);
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
+BOOST_AUTO_TEST_CASE(limit_order_update_match_test_2)
+{
+   try {
+      ACTORS((nathan));
+      const auto& munee = create_user_issued_asset("MUNEE");
+
+      transfer(committee_account, nathan_id, asset(10000));
+      issue_uia(nathan, munee.amount(1000));
+
+      auto expiration = db.head_block_time() + 1000;
+      limit_order_id_type order_id_1 = create_sell_order(nathan, asset(999), munee.amount(100), expiration)->id;
+      limit_order_id_type order_id_2 = create_sell_order(nathan, munee.amount(100), asset(1001), expiration)->id;
+
+      update_limit_order(order_id_2, price(munee.amount(100), asset(999)));
+      BOOST_REQUIRE_EQUAL(db.find(order_id_1), nullptr);
+      BOOST_REQUIRE_EQUAL(db.find(order_id_2), nullptr);
+   } catch (fc::exception& e) {
+      edump((e.to_detail_string()));
+      throw;
+   }
+}
+
 BOOST_AUTO_TEST_CASE( call_order_update_test )
 {
    try {

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -111,6 +111,9 @@ BOOST_AUTO_TEST_CASE(limit_order_update_test)
       GRAPHENE_REQUIRE_THROW(update_limit_order(order_id), fc::assert_exception);
       // Cannot update order to use inverted price assets
       GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(bitusd.amount(2), asset(1))), fc::assert_exception);
+      // Cannot update order to use negative price
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(asset(-1), bitusd.amount(2))), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(asset(1), bitusd.amount(-2))), fc::assert_exception);
       // Cannot update order to use different assets
       GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(bitusd.amount(2), munee.amount(1))), fc::assert_exception);
       GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, price(munee.amount(2), bitusd.amount(1))), fc::assert_exception);

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -148,9 +148,11 @@ BOOST_AUTO_TEST_CASE(limit_order_update_test)
       expiration += 50;
       update_limit_order(order_id, {}, {}, expiration);
       BOOST_REQUIRE_EQUAL(order_id(db).expiration.sec_since_epoch(), expiration.sec_since_epoch());
-      expiration -= 100;
-      update_limit_order(order_id, {}, {}, expiration);
-      BOOST_REQUIRE_EQUAL(order_id(db).expiration.sec_since_epoch(), expiration.sec_since_epoch());
+      // Cannot make expiration same as before
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, {}, expiration), fc::assert_exception);
+      // Cannot make expiration sooner; only later
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, {}, expiration - 100), fc::assert_exception);
+      GRAPHENE_REQUIRE_THROW(update_limit_order(order_id, {}, {}, expiration - 1), fc::assert_exception);
 
       // Try adding funds
       update_limit_order(order_id, {}, asset(50));

--- a/tests/tests/operation_tests.cpp
+++ b/tests/tests/operation_tests.cpp
@@ -88,6 +88,8 @@ BOOST_AUTO_TEST_CASE(limit_order_update_test)
       const auto& munee = create_user_issued_asset("MUNEE");
       const auto& core   = asset_id_type()(db);
 
+      generate_blocks(HARDFORK_CORE_1604_TIME + 10);
+
       update_feed_producers(bitusd, {nathan_id});
       price_feed current_feed;
       current_feed.settlement_price = bitusd.amount(200) / core.amount(100);
@@ -178,6 +180,8 @@ BOOST_AUTO_TEST_CASE(limit_order_update_dust_test)
       ACTORS((nathan));
       const auto& munee = create_user_issued_asset("MUNEE");
 
+      generate_blocks(HARDFORK_CORE_1604_TIME + 10);
+
       transfer(committee_account, nathan_id, asset(10000));
       issue_uia(nathan, munee.amount(1000));
 
@@ -198,6 +202,8 @@ BOOST_AUTO_TEST_CASE(limit_order_update_match_test)
    try {
       ACTORS((nathan));
       const auto& munee = create_user_issued_asset("MUNEE");
+
+      generate_blocks(HARDFORK_CORE_1604_TIME + 10);
 
       transfer(committee_account, nathan_id, asset(10000));
       issue_uia(nathan, munee.amount(1000));
@@ -220,6 +226,8 @@ BOOST_AUTO_TEST_CASE(limit_order_update_match_test_2)
    try {
       ACTORS((nathan));
       const auto& munee = create_user_issued_asset("MUNEE");
+
+      generate_blocks(HARDFORK_CORE_1604_TIME + 10);
 
       transfer(committee_account, nathan_id, asset(10000));
       issue_uia(nathan, munee.amount(1000));


### PR DESCRIPTION
This PR exists to provide a permanent home for a mostly clutter-free example of creating a simple new operation and evaluator in BitShares, namely the `limit_order_update_operation`. Please note that the changes in 8a82d92 are present as a necessary, but ancillary modification and are not typical of creating a new operation or evaluator.